### PR TITLE
Add option to perform to include or remove hidden fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluent-siren-client",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Fluent client for Siren Hyper Media APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- When hidden fields are added, they are flattened because they are parsed as flat fields by the siren parser.  The issue arises when they are merged with a structured object.
- I added a includeHiddenFields which is enabled by default to preserve existing behavior.  It allows calling perform without merging in the hidden field values.
- We're not sure why, but it appears that default values were never preserved here.

For context, an object `{ field: { nestedField: 'value' } }` would be flattened to form data as (encoded) `field[nestedField]=value`.  Siren parses this as a flattened object as `{ "field[nestedField]": value }`